### PR TITLE
Compatibility with Ruby 3.2

### DIFF
--- a/lib/non-stupid-digest-assets.rb
+++ b/lib/non-stupid-digest-assets.rb
@@ -30,13 +30,13 @@ module NonStupidDigestAssets
         full_non_digest_path = File.join dir, logical_path
         full_non_digest_gz_path = "#{full_non_digest_path}.gz"
 
-        if File.exists? full_digest_path
+        if File.exist? full_digest_path
           logger.debug "Writing #{full_non_digest_path}"
           FileUtils.copy_file full_digest_path, full_non_digest_path, :preserve_attributes
         else
           logger.debug "Could not find: #{full_digest_path}"
         end
-        if File.exists? full_digest_gz_path
+        if File.exist? full_digest_gz_path
           logger.debug "Writing #{full_non_digest_gz_path}"
           FileUtils.copy_file full_digest_gz_path, full_non_digest_gz_path, :preserve_attributes
         else


### PR DESCRIPTION
Ruby 3.2 removes the alias ´File.exists?´ in favor of ´File.exist?´. Taken from https://github.com/afdev82/non-stupid-digest-assets/tree/patch-1